### PR TITLE
VCST-4330: Use .Net 10 Dockerfile

### DIFF
--- a/VirtoLocal_create_local_files.ps1
+++ b/VirtoLocal_create_local_files.ps1
@@ -73,8 +73,8 @@ Write-Host "... Scripts-helpers downloaded" -ForegroundColor Green
 # download config files for the backend
 Write-Host "Downloading config files for the backend..." -ForegroundColor Yellow
 New-Folder $backendDir
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/VirtoCommerce/vc-docker/feat/net8/linux/platform/Dockerfile" -OutFile (Join-Path $backendDir "Dockerfile")
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/VirtoCommerce/vc-docker/feat/net8/linux/platform/wait-for-it.sh" -OutFile (Join-Path $backendDir "wait-for-it.sh")
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/VirtoCommerce/vc-docker/feat/net10/linux/platform/Dockerfile" -OutFile (Join-Path $backendDir "Dockerfile")
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/VirtoCommerce/vc-docker/feat/net10/linux/platform/wait-for-it.sh" -OutFile (Join-Path $backendDir "wait-for-it.sh")
 Write-Host "... Config files for the backend downloaded" -ForegroundColor Green
 
 #download config files for the frontend


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: updates only the remote URLs used by a local setup script; impact is limited to local environment bootstrapping if the new vc-docker branch/paths change or are unavailable.
> 
> **Overview**
> Updates `VirtoLocal_create_local_files.ps1` to download the backend `Dockerfile` and `wait-for-it.sh` from the `.NET 10` (`vc-docker/feat/net10`) paths instead of the previous `.NET 8` (`feat/net8`) paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f6737eeb82bd0196b367eca531006d085c522bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->