### PR TITLE
VCST-5145: Add custom packages.json mode to build-VC-solution.ps1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following files and folders will be created:
 
 By default `build-VC-solution` script is executed automatically after the files are created and `start-VC-solution` script is executed automatically after the build is complete. However, the execution can be skipped.
 
-You have two options for installing Virto Commerce: using the latest stable release or the edge release. Learn more about our release strategy by [following this link](https://docs.virtocommerce.org/platform/developer-guide/Updating-Virto-Commerce-Based-Project/release-strategy-overview/).
+You have three options for installing Virto Commerce: the latest stable release, the edge release, or a user-supplied custom package manifest. Learn more about our release strategy by [following this link](https://docs.virtocommerce.org/platform/developer-guide/Updating-Virto-Commerce-Based-Project/release-strategy-overview/).
 
 ### Endpoints
 After running the script:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,22 @@ The manual installation steps are as follows:
 - `vcSolutionVersion`:
     - `latest-stable`: Installs the latest stable backend bundle with compatible frontend
     - `edge`: Installs the newest backend and frontend releases
+    - `custom`: Installs a user-supplied backend package manifest. Requires `-customPackagesJson`. Optionally accepts `-customFrontendUrl`; if omitted, the script prompts for it and falls back to the latest `vc-frontend` GitHub release when left blank.
+- `customPackagesJson` (used only with `-vcSolutionVersion custom`): Path to a local `package.json` manifest **or** an `http(s)://` URL. Auto-detected. The file is copied/downloaded to `<targetFolder>\backend\custom-packages.json` and passed to `vc-build install --package-manifest-path`.
+- `customFrontendUrl` (used only with `-vcSolutionVersion custom`, optional): Direct URL to a frontend ZIP artifact. If not provided, the script prompts; leaving the prompt empty falls back to the latest `vc-frontend` GitHub release.
 - `skipSampleData` (optional, default `$false`): pass `$true` to skip sample data installation when the start step is invoked automatically
+
+Custom-mode examples:
+
+```pwsh
+# Local manifest, frontend from GitHub release fallback
+.\build-VC-solution.ps1 -vcSolutionVersion custom -customPackagesJson .\my-packages.json
+
+# Remote manifest + explicit frontend ZIP URL (no prompts)
+.\build-VC-solution.ps1 -vcSolutionVersion custom `
+    -customPackagesJson https://example.com/my-bundle/package.json `
+    -customFrontendUrl https://example.com/my-frontend.zip
+```
 
 2. Then run `start-VC-solution.ps1` to launch:
 - Virtocommerce backend/frontend

--- a/VirtoLocal_create_local_files.ps1
+++ b/VirtoLocal_create_local_files.ps1
@@ -185,11 +185,15 @@ if ($proceed -eq "" -or $proceed -eq "y" -or $proceed -eq "Y") {
         Write-Host "Sample data will be installed." -ForegroundColor Green
     }
 
-    $buildCmd = "./$targetFolder/build-VC-solution.ps1 -vcSolutionVersion $vcSolutionVersion -skipSampleData `$$skipSampleData"
-    if ($vcSolutionVersion -eq "custom") {
-        $buildCmd += " -customPackagesJson '$customPackagesJson' -customFrontendUrl '$customFrontendUrl'"
+    $buildArgs = @{
+        vcSolutionVersion = $vcSolutionVersion
+        skipSampleData    = $skipSampleData
     }
-    Invoke-Expression $buildCmd
+    if ($vcSolutionVersion -eq "custom") {
+        $buildArgs.customPackagesJson = $customPackagesJson
+        $buildArgs.customFrontendUrl  = $customFrontendUrl
+    }
+    & "./$targetFolder/build-VC-solution.ps1" @buildArgs
 }
 else {
     Write-Host "Build process skipped. You can run it manually later using: ./$targetFolder/build-VC-solution.ps1" -ForegroundColor Yellow

--- a/VirtoLocal_create_local_files.ps1
+++ b/VirtoLocal_create_local_files.ps1
@@ -155,11 +155,21 @@ if ($proceed -eq "" -or $proceed -eq "y" -or $proceed -eq "Y") {
     Write-Host "Select the version to install:" -ForegroundColor Cyan
     Write-Host "1. latest-stable - Latest stable bundle of backend with compatible frontend" -ForegroundColor White
     Write-Host "2. edge - Latest available releases of backend and frontend" -ForegroundColor White
-    $versionChoice = Read-Host "Enter your choice (1 or 2, default is 1)"
+    Write-Host "3. custom - Build with a user-supplied package manifest" -ForegroundColor White
+    $versionChoice = Read-Host "Enter your choice (1, 2, or 3, default is 1)"
 
     $vcSolutionVersion = "latest-stable"  # default
+    $customPackagesJson = ""
+    $customFrontendUrl = ""
     if ($versionChoice -eq "2") {
         $vcSolutionVersion = "edge"
+    }
+    elseif ($versionChoice -eq "3") {
+        $vcSolutionVersion = "custom"
+        while ([string]::IsNullOrWhiteSpace($customPackagesJson)) {
+            $customPackagesJson = Read-Host "Enter path or URL to custom package manifest (required)"
+        }
+        $customFrontendUrl = Read-Host "Enter custom frontend ZIP URL (leave empty to use the latest vc-frontend GitHub release)"
     }
 
     Write-Host "Using version: $vcSolutionVersion" -ForegroundColor Green
@@ -175,7 +185,14 @@ if ($proceed -eq "" -or $proceed -eq "y" -or $proceed -eq "Y") {
         Write-Host "Sample data will be installed." -ForegroundColor Green
     }
 
-    Invoke-Expression "./$targetFolder/build-VC-solution.ps1 -vcSolutionVersion $vcSolutionVersion -skipSampleData `$$skipSampleData"
+    $buildCmd = "./$targetFolder/build-VC-solution.ps1 -vcSolutionVersion $vcSolutionVersion -skipSampleData `$$skipSampleData"
+    if ($vcSolutionVersion -eq "custom") {
+        $buildCmd += " -customPackagesJson '$customPackagesJson'"
+        if (-not [string]::IsNullOrWhiteSpace($customFrontendUrl)) {
+            $buildCmd += " -customFrontendUrl '$customFrontendUrl'"
+        }
+    }
+    Invoke-Expression $buildCmd
 }
 else {
     Write-Host "Build process skipped. You can run it manually later using: ./$targetFolder/build-VC-solution.ps1" -ForegroundColor Yellow

--- a/VirtoLocal_create_local_files.ps1
+++ b/VirtoLocal_create_local_files.ps1
@@ -187,10 +187,7 @@ if ($proceed -eq "" -or $proceed -eq "y" -or $proceed -eq "Y") {
 
     $buildCmd = "./$targetFolder/build-VC-solution.ps1 -vcSolutionVersion $vcSolutionVersion -skipSampleData `$$skipSampleData"
     if ($vcSolutionVersion -eq "custom") {
-        $buildCmd += " -customPackagesJson '$customPackagesJson'"
-        if (-not [string]::IsNullOrWhiteSpace($customFrontendUrl)) {
-            $buildCmd += " -customFrontendUrl '$customFrontendUrl'"
-        }
+        $buildCmd += " -customPackagesJson '$customPackagesJson' -customFrontendUrl '$customFrontendUrl'"
     }
     Invoke-Expression $buildCmd
 }

--- a/build-VC-solution.ps1
+++ b/build-VC-solution.ps1
@@ -1,7 +1,9 @@
 param (
     [string]$targetFolder = "VirtoLocal",
-    [ValidateSet("latest-stable", "edge")]
+    [ValidateSet("latest-stable", "edge", "custom")]
     [string]$vcSolutionVersion = "latest-stable",
+    [string]$customPackagesJson,
+    [string]$customFrontendUrl,
     [bool]$skipSampleData = $false
 )
 
@@ -21,15 +23,50 @@ if ($vcSolutionVersion -eq "latest-stable") {
     $packagesJsonUrl = "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/refs/heads/master/bundles/$vcModulesBundle/package.json"
     $frontendZipUrl = (Invoke-WebRequest -Uri $packagesJsonUrl).Content | ConvertFrom-Json | Select-Object -ExpandProperty "ThemeB2BVue"
 }
-else {
+elseif ($vcSolutionVersion -eq "edge") {
     $vcModulesBundle = "edge"
     $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/VirtoCommerce/vc-frontend/releases/latest"
     $frontendZipUrl = $releaseInfo.assets.browser_download_url
+}
+else {
+    if ([string]::IsNullOrWhiteSpace($customPackagesJson)) {
+        Write-Host "Error: -customPackagesJson is required when -vcSolutionVersion is 'custom'." -ForegroundColor Red
+        exit 1
+    }
+    if ([string]::IsNullOrWhiteSpace($customFrontendUrl)) {
+        $customFrontendUrl = Read-Host "Enter custom frontend ZIP URL (leave empty to use the latest vc-frontend GitHub release)"
+    }
+    if ([string]::IsNullOrWhiteSpace($customFrontendUrl)) {
+        $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/VirtoCommerce/vc-frontend/releases/latest"
+        $frontendZipUrl = $releaseInfo.assets.browser_download_url
+    }
+    else {
+        $frontendZipUrl = $customFrontendUrl
+    }
 }
 
 # build backend
 $backendDir = Join-Path $targetFolder "backend"
 New-Folder $backendDir
+
+if ($vcSolutionVersion -eq "custom") {
+    $customPackagesJsonPath = Join-Path $backendDir "custom-packages.json"
+    if ($customPackagesJson -match '^https?://') {
+        Write-Host "Downloading custom package manifest from $customPackagesJson..." -ForegroundColor Yellow
+        Invoke-WebRequest -Uri $customPackagesJson -OutFile $customPackagesJsonPath
+    }
+    else {
+        try {
+            $resolvedSource = (Resolve-Path -Path $customPackagesJson -ErrorAction Stop).Path
+        }
+        catch {
+            Write-Host "Error: custom package manifest not found at '$customPackagesJson'." -ForegroundColor Red
+            exit 1
+        }
+        Copy-Item -Path $resolvedSource -Destination $customPackagesJsonPath -Force
+    }
+}
+
 if ($vcSolutionVersion -eq "latest-stable") {
     # build latest stable
     $stablePackagesJsonUrl = "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/refs/heads/master/bundles/$vcModulesBundle/package.json"
@@ -49,10 +86,25 @@ if ($vcSolutionVersion -eq "latest-stable") {
     }
     Write-Host "... Backend built successfully" -ForegroundColor Green
 }
-else {
+elseif ($vcSolutionVersion -eq "edge") {
     # build latest dev
     Write-Host "Building backend..." -ForegroundColor Yellow
     vc-build install -Edge `
+        --probing-path $backendDir/publish/app_data/modules `
+        --discovery-path $backendDir/publish/modules `
+        --root $backendDir/publish `
+        --skip-dependency-solving
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Error: Failed to build backend" -ForegroundColor Red
+        Write-Host "Build command failed with exit code: $LASTEXITCODE" -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "... Backend built successfully" -ForegroundColor Green
+}
+else {
+    # build with custom package manifest
+    Write-Host "Building backend with custom package manifest..." -ForegroundColor Yellow
+    vc-build install --package-manifest-path $customPackagesJsonPath `
         --probing-path $backendDir/publish/app_data/modules `
         --discovery-path $backendDir/publish/modules `
         --root $backendDir/publish `

--- a/build-VC-solution.ps1
+++ b/build-VC-solution.ps1
@@ -65,6 +65,26 @@ if ($vcSolutionVersion -eq "custom") {
         }
         Copy-Item -Path $resolvedSource -Destination $customPackagesJsonPath -Force
     }
+
+    # Verify the manifest is well-formed JSON and has the required fields
+    try {
+        $manifest = Get-Content -Raw -Path $customPackagesJsonPath | ConvertFrom-Json -ErrorAction Stop
+    }
+    catch {
+        Write-Host "Error: custom package manifest at '$customPackagesJsonPath' is not valid JSON: $($_.Exception.Message)" -ForegroundColor Red
+        exit 1
+    }
+    if (-not $manifest.PlatformVersion) {
+        Write-Host "Error: custom package manifest is missing required field 'PlatformVersion'." -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "Custom manifest verified: PlatformVersion = $($manifest.PlatformVersion)" -ForegroundColor Green
+    try {
+        [void][System.Version]::Parse(($manifest.PlatformVersion -split '-', 2)[0])
+    }
+    catch {
+        Write-Host "Warning: PlatformVersion '$($manifest.PlatformVersion)' may not be parseable by vc-build (System.Version expects numeric major.minor[.build[.revision]] before any prerelease suffix)." -ForegroundColor Yellow
+    }
 }
 
 if ($vcSolutionVersion -eq "latest-stable") {

--- a/build-VC-solution.ps1
+++ b/build-VC-solution.ps1
@@ -33,6 +33,8 @@ else {
         Write-Host "Error: -customPackagesJson is required when -vcSolutionVersion is 'custom'." -ForegroundColor Red
         exit 1
     }
+    # Only prompts on direct CLI invocation. VirtoLocal_create_local_files.ps1 always
+    # passes -customFrontendUrl (possibly empty), so ContainsKey() is true and this is skipped.
     if ([string]::IsNullOrWhiteSpace($customFrontendUrl) -and -not $PSBoundParameters.ContainsKey('customFrontendUrl')) {
         $customFrontendUrl = Read-Host "Enter custom frontend ZIP URL (leave empty to use the latest vc-frontend GitHub release)"
     }
@@ -47,13 +49,19 @@ else {
 
 # build backend
 $backendDir = Join-Path $targetFolder "backend"
+$customPackagesJsonPath = Join-Path $backendDir "custom-packages.json"
 New-Folder $backendDir
 
 if ($vcSolutionVersion -eq "custom") {
-    $customPackagesJsonPath = Join-Path $backendDir "custom-packages.json"
     if ($customPackagesJson -match '^https?://') {
         Write-Host "Downloading custom package manifest from $customPackagesJson..." -ForegroundColor Yellow
-        Invoke-WebRequest -Uri $customPackagesJson -OutFile $customPackagesJsonPath
+        try {
+            Invoke-WebRequest -Uri $customPackagesJson -OutFile $customPackagesJsonPath -ErrorAction Stop
+        }
+        catch {
+            Write-Host "Error: failed to download custom package manifest from '$customPackagesJson': $($_.Exception.Message)" -ForegroundColor Red
+            exit 1
+        }
     }
     else {
         try {

--- a/build-VC-solution.ps1
+++ b/build-VC-solution.ps1
@@ -33,7 +33,7 @@ else {
         Write-Host "Error: -customPackagesJson is required when -vcSolutionVersion is 'custom'." -ForegroundColor Red
         exit 1
     }
-    if ([string]::IsNullOrWhiteSpace($customFrontendUrl)) {
+    if ([string]::IsNullOrWhiteSpace($customFrontendUrl) -and -not $PSBoundParameters.ContainsKey('customFrontendUrl')) {
         $customFrontendUrl = Read-Host "Enter custom frontend ZIP URL (leave empty to use the latest vc-frontend GitHub release)"
     }
     if ([string]::IsNullOrWhiteSpace($customFrontendUrl)) {


### PR DESCRIPTION
## Summary

Adds a third `custom` mode to `build-VC-solution.ps1` so a user-supplied package manifest can drive the build instead of the hardcoded `VirtoCommerce/vc-modules` GitHub bundle. Useful for forked bundles, pinned module sets, and per-customer / PR-build configs.

### New parameters on `build-VC-solution.ps1`

- `-customPackagesJson <path-or-url>` — required when `-vcSolutionVersion custom`. Auto-detected: values starting with `http(s)://` are downloaded, anything else is resolved as a local path. The manifest is copied/downloaded to `<targetFolder>\backend\custom-packages.json` and passed to `vc-build install --package-manifest-path`.
- `-customFrontendUrl <url>` — optional. Direct URL to a frontend ZIP. If omitted on direct CLI invocation the script prompts; leaving the prompt empty falls back to the latest `vc-frontend` GitHub release (same source `edge` mode uses).

### Orchestrator changes

`VirtoLocal_create_local_files.ps1` gains a `3. custom` option in its interactive version menu, prompts for the manifest path/URL (with retry loop) and the optional frontend URL, then passes everything through to the child script via splatting (`& ./build-VC-solution.ps1 @buildArgs`) — quote-safe for paths containing apostrophes. The child uses `$PSBoundParameters.ContainsKey('customFrontendUrl')` to suppress its own prompt when the orchestrator handed off, avoiding a double-prompt.

### Manifest validation

Before invoking `vc-build`, the script:
1. Parses the manifest with `ConvertFrom-Json` — malformed JSON fails fast with a styled error.
2. Requires `PlatformVersion` to be present.
3. Warns (non-fatal) when the numeric prefix of `PlatformVersion` doesn't parse as `System.Version` — vc-build itself throws `FormatException` on prerelease-suffixed versions like `3.1000.0-pr-2965-…`, so this surfaces the cause before the build noisy-fails.
4. Wraps `Invoke-WebRequest` in `try/catch` so a 404/timeout produces a clean red error + `exit 1` instead of a stack trace.

Existing `latest-stable` and `edge` modes are untouched (verified by visual diff — both branches are byte-identical to before the `if/else` → `if/elseif/else` restructure).

### README

Updated the "Manual Installation" section with the new mode, both new parameters, and two usage examples (local file + remote URL).

## Test plan

- [x] `./build-VC-solution.ps1` — default `latest-stable` still works, no new prompts.
- [x] `./build-VC-solution.ps1 -vcSolutionVersion edge` — still works.
- [x] `./build-VC-solution.ps1 -vcSolutionVersion custom` — exits with the "is required" red error.
- [x] `./build-VC-solution.ps1 -vcSolutionVersion custom -customPackagesJson .\my-pkg.json` — copies local file, prompts for frontend URL, blank prompt falls back to GH release.
- [x] `./build-VC-solution.ps1 -vcSolutionVersion custom -customPackagesJson https://… -customFrontendUrl https://…` — no prompts, both URLs honored.
- [x] `./build-VC-solution.ps1 -vcSolutionVersion custom -customPackagesJson https://invalid.example/404.json` — clean red error from the `try/catch`, no stack trace.
- [x] `./build-VC-solution.ps1 -vcSolutionVersion custom -customPackagesJson <manifest-without-PlatformVersion>` — "missing required field" error.
- [x] `./build-VC-solution.ps1 -vcSolutionVersion custom -customPackagesJson <manifest-with-prerelease-version>` — yellow warning printed, then vc-build runs (and may itself fail on the version format — known upstream limitation).
- [x] `./VirtoLocal_create_local_files.ps1` → choose `3. custom` → enter manifest → leave frontend blank → confirm the child does **not** re-prompt for the frontend URL.
- [x] Path with apostrophe (e.g. `C:\Andrew's data\pkg.json`) flows from orchestrator → child without quoting errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to PowerShell install/build orchestration and documentation; existing stable and edge paths are preserved with explicit elseif branches.
> 
> **Overview**
> Adds a **custom** install path alongside `latest-stable` and `edge` so local Docker builds can be driven by a user-supplied `package.json` instead of only the bundled vc-modules GitHub manifests.
> 
> `build-VC-solution.ps1` now accepts `-vcSolutionVersion custom` with **`-customPackagesJson`** (local path or HTTP(S) URL, staged as `backend/custom-packages.json`) and optional **`-customFrontendUrl`** (otherwise prompts on direct CLI use, or falls back to the latest `vc-frontend` GitHub release). Custom mode validates JSON, requires `PlatformVersion`, warns on unparsable version prefixes, and runs `vc-build install --package-manifest-path` for the backend. The setup orchestrator adds menu option **3**, collects manifest/frontend inputs, and invokes the build script via splatting so paths with special characters are safe; **`$PSBoundParameters.ContainsKey('customFrontendUrl')`** avoids a second frontend prompt when the parent already passed the parameter.
> 
> README documents the third mode, new parameters, and example commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7642a29a83444d9dbe3fa2379e3ff65e55fe38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->